### PR TITLE
Watchdog: never connect() on server-side incoming sockets (url=null)

### DIFF
--- a/src/ToolSocket.js
+++ b/src/ToolSocket.js
@@ -252,7 +252,16 @@ class ToolSocket {
                 try {
                     this.socket.close();
                 } catch (_e) { /* best effort; we're replacing it anyway */ }
-                this.connect(this.url, this.networkId, this.origin);
+                if (this.url) {
+                    // outbound socket: dial a fresh connection
+                    this.connect(this.url, this.networkId, this.origin);
+                } else if (this.socket.terminate) {
+                    // server-side incoming socket (IncomingToolSocket, url=null): there is
+                    // nothing to dial — connect(null) would throw and crash the server.
+                    // Terminate the dead transport so 'close' fires and the server reaps
+                    // the connection; the CLIENT's own watchdog/reconnect re-establishes.
+                    try { this.socket.terminate(); } catch (_e) { /* already dead */ }
+                }
                 return;
             }
             this.ping('action/ping', null, () => {

--- a/src/ToolSocket.js
+++ b/src/ToolSocket.js
@@ -260,7 +260,9 @@ class ToolSocket {
                     // nothing to dial — connect(null) would throw and crash the server.
                     // Terminate the dead transport so 'close' fires and the server reaps
                     // the connection; the CLIENT's own watchdog/reconnect re-establishes.
-                    try { this.socket.terminate(); } catch (_e) { /* already dead */ }
+                    try {
+                        this.socket.terminate();
+                    } catch (_e) { /* already dead */ }
                 }
                 return;
             }


### PR DESCRIPTION
The liveness watchdog runs in setupPingInterval on EVERY socket, including the server-side IncomingToolSocket a ToolSocket.Server holds per connection. Those have url=null, so when a CLIENT went silently half-open the watchdog called this.connect(null) -> new URL('null') throws -> uncaught TypeError killed the whole server process (proxy/edge would die ~16s after any silent client). Now: outbound sockets (url set) reconnect as before; incoming sockets terminate the dead transport instead, so 'close' fires, the server reaps the connection, and the client's own watchdog/reconnect re-establishes.

Found by an NB-enhanced freeze test (SIGSTOP peer); verified: watchdog still fires at ~16-21s under NB, recovery + NB re-handshake clean, server no longer crashes. npm test 56/56 + test:nb pass.